### PR TITLE
Modify TTY device name due to issue in Neovim 0.9

### DIFF
--- a/autoload/it2touchbar.vim
+++ b/autoload/it2touchbar.vim
@@ -17,7 +17,7 @@ function! it2touchbar#WriteTTY(message)
 	setlocal binary
 	setlocal nofixendofline
 	call setline(1, a:message)
-	execute 'w >>' '/dev/ttys000'
+	execute 'w >>' '/dev/fd/1'
 	q
 endfunction
 

--- a/autoload/it2touchbar.vim
+++ b/autoload/it2touchbar.vim
@@ -17,7 +17,7 @@ function! it2touchbar#WriteTTY(message)
 	setlocal binary
 	setlocal nofixendofline
 	call setline(1, a:message)
-	execute 'w >>' '/dev/tty'
+	execute 'w >>' '/dev/ttys000'
 	q
 endfunction
 


### PR DESCRIPTION
See https://neovim.discourse.group/t/writefile-to-dev-tty-stopped-working-in-nvim-0-9/3784/2.