### PR TITLE
Implement usage of built-in `writefile` function

### DIFF
--- a/autoload/it2touchbar.vim
+++ b/autoload/it2touchbar.vim
@@ -10,8 +10,8 @@ endif
 " This is necessary to send ANSI escape sequence.
 "
 " Note: This may reset the mode to normal.
-function! it2touchbar#WriteStdout(message)
-	call writefile([a:message], '/dev/fd/1', "ba")
+function! it2touchbar#WriteStdout(command, message)
+	call writefile([ "]1337;".a:command."=".a:message."" ], '/dev/fd/1', "ba")
 endfunction
 
 " Functions for manipulating the touch bar.
@@ -19,16 +19,16 @@ let s:key_label_cache = {}
 function! it2touchbar#SetTouchBarKey(key, value)
 	if !has_key(s:key_label_cache, a:key) || s:key_label_cache[a:key] != a:value
 		let s:key_label_cache[a:key] = a:value
-		silent call it2touchbar#WriteStdout(']1337;SetKeyLabel='.a:key.'='.a:value.'')
+		call it2touchbar#WriteStdout('SetKeyLabel', a:key."=".a:value)
 	endif
 endfunction
 
 function! it2touchbar#PushKeys(label)
-	silent call it2touchbar#WriteStdout(']1337;PushKeyLabels='.a:label.'')
+	call it2touchbar#WriteStdout('PushKeyLabels', a:label)
 endfunction
 
 function! it2touchbar#PopKeys(label)
-	silent call it2touchbar#WriteStdout(']1337;PopKeyLabels='.a:label.'')
+	call it2touchbar#WriteStdout('PopKeyLabels', a:label)
 endfunction
 
 " Function to regenerate the touchbar keys.

--- a/autoload/it2touchbar.vim
+++ b/autoload/it2touchbar.vim
@@ -6,19 +6,12 @@ if !exists('g:loaded_it2touchbar')
 	finish
 endif
 
-" Writes directly to the terminal.
+" Writes directly to the 'stdout' file descriptor.
 " This is necessary to send ANSI escape sequence.
 "
 " Note: This may reset the mode to normal.
-function! it2touchbar#WriteTTY(message)
-	new
-	setlocal buftype=nofile bufhidden=hide noswapfile nobuflisted
-	setlocal noeol
-	setlocal binary
-	setlocal nofixendofline
-	call setline(1, a:message)
-	execute 'w >>' '/dev/fd/1'
-	q
+function! it2touchbar#WriteStdout(message)
+	call writefile([a:message], '/dev/fd/1', "ba")
 endfunction
 
 " Functions for manipulating the touch bar.
@@ -26,16 +19,16 @@ let s:key_label_cache = {}
 function! it2touchbar#SetTouchBarKey(key, value)
 	if !has_key(s:key_label_cache, a:key) || s:key_label_cache[a:key] != a:value
 		let s:key_label_cache[a:key] = a:value
-		silent call it2touchbar#WriteTTY(']1337;SetKeyLabel='.a:key.'='.a:value.'')
+		silent call it2touchbar#WriteStdout(']1337;SetKeyLabel='.a:key.'='.a:value.'')
 	endif
 endfunction
 
 function! it2touchbar#PushKeys(label)
-	silent call it2touchbar#WriteTTY(']1337;PushKeyLabels='.a:label.'')
+	silent call it2touchbar#WriteStdout(']1337;PushKeyLabels='.a:label.'')
 endfunction
 
 function! it2touchbar#PopKeys(label)
-	silent call it2touchbar#WriteTTY(']1337;PopKeyLabels='.a:label.'')
+	silent call it2touchbar#WriteStdout(']1337;PopKeyLabels='.a:label.'')
 endfunction
 
 " Function to regenerate the touchbar keys.


### PR DESCRIPTION
Vim provides a built-in function that writes a string to a file so creating a buffer to do so is not necessary. I've implemented said function in the body of the `WriteStdout` (previously `WriteTTY`) function, and also tweaked the function arguments a bit to reduce some redundancy.

Tested against Vim 9.0.1424 and Neovim 0.9.1, works with both.